### PR TITLE
Fix proxy-aware redirect in auth_check_and_proxy for correct login page routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "runegate"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "actix-files",
  "actix-governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runegate"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Hans Van Wesenbeeck <hvw@aivolution.ch>"]
 license = "Apache-2.0"
 edition = "2024"


### PR DESCRIPTION
## Changes in this PR

This PR implements the **Bugfix/auth Check Proxy Awareness** feature.

## Commit History

 - **Fix proxy-aware redirect in auth_check_and_proxy for correct login page routing**


## Checklist

- [x] Documentation updated
- [x] Tests added/updated
- [x] Code reviewed


