### PR TITLE
release: 0.2.0 — auth/session fixes, identity headers, prod docs, cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 # Core Configuration
 # =============================================================================
 
+# Environment mode: 'production' for production, unset/any other value for development
+# When set to 'production', JWT and session secrets become required
+# RUNEGATE_ENV=production
+
 # JWT secret for token signing (recommended for production)
 # RUNEGATE_JWT_SECRET=your_secure_jwt_secret
 
@@ -16,6 +20,9 @@
 
 # Base URL for magic links (defaults to http://localhost:7870)
 # RUNEGATE_BASE_URL=https://your-public-url
+
+# Optional: Cookie Domain attribute. If unset, a host-only cookie is used (recommended).
+# RUNEGATE_COOKIE_DOMAIN=your.domain.tld
 
 # Magic link expiry time in minutes (defaults to 15)
 # RUNEGATE_MAGIC_LINK_EXPIRY=60
@@ -29,6 +36,47 @@ RUST_LOG=info
 
 # Logging format: 'console' (default) or 'json'
 # RUNEGATE_LOG_FORMAT=json
+
+# =============================================================================
+# Session Cookie
+# =============================================================================
+
+# Optional: Customize the session cookie name (default: runegate_id)
+# RUNEGATE_SESSION_COOKIE_NAME=runegate_id
+
+# Optional: Enable debug endpoints (/debug/session, /debug/cookies, /debug/protected)
+# Defaults: disabled in production, enabled in development unless explicitly set.
+# RUNEGATE_DEBUG_ENDPOINTS=false
+
+# Optional: Inject identity headers to the target service
+# When enabled, Runegate injects X-Runegate-Authenticated, X-Runegate-User,
+# X-Forwarded-User, and X-Forwarded-Email for authenticated requests.
+# It also strips any client-supplied versions of these headers before forwarding.
+# Default: true
+# RUNEGATE_IDENTITY_HEADERS=true
+
+# =============================================================================
+# Identity to Target (Future - JWT mode)
+# =============================================================================
+# If you choose to enable JWT identity propagation in the future, the following
+# variables will be used (subject to change):
+
+# RUNEGATE_IDENTITY_MODE=jwt                   # headers | jwt | none
+# RUNEGATE_DOWNSTREAM_JWT_ALG=RS256            # RS256 | EdDSA | HS256
+# RUNEGATE_DOWNSTREAM_JWT_TTL=600              # Token TTL in seconds
+# RUNEGATE_DOWNSTREAM_JWT_ISS=runegate         # Issuer claim
+# RUNEGATE_DOWNSTREAM_JWT_AUD=your-target      # Audience claim
+# RUNEGATE_DOWNSTREAM_JWT_HEADER=Authorization # Header to carry token
+# RUNEGATE_DOWNSTREAM_JWT_BEARER=true          # Prefix with "Bearer "
+
+# Key material (choose one approach based on algorithm)
+# RUNEGATE_DOWNSTREAM_JWT_PRIVATE_KEY_PATH=/etc/runegate/keys/downstream_private.pem
+# RUNEGATE_DOWNSTREAM_JWT_PRIVATE_KEY_BASE64=...   # Optional inline alternative
+# RUNEGATE_DOWNSTREAM_JWT_SECRET=...               # For HS256 only
+
+# Optional JWKS publishing (if targets fetch public keys)
+# RUNEGATE_DOWNSTREAM_JWKS_ENABLED=false
+# RUNEGATE_DOWNSTREAM_JWKS_PATH=/jwks.json
 
 # =============================================================================
 # Rate Limiting Configuration

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 /target
 /config/email.toml
 /cookies.txt
+/.env.production
+/.test_server_pid
+/_test_server_pid
+/_test_server.log
+/test_server.log
+/headers.txt
 *.code-workspace
 .test_server_pid
+.env
 *.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.1",
+ "rand 0.9.2",
  "sha1",
  "smallvec",
  "tokio",
@@ -140,7 +140,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
@@ -240,7 +240,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "time",
  "tracing",
  "url",
@@ -407,7 +407,7 @@ dependencies = [
  "openssl",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1008,7 +1008,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.1",
+ "rand 0.9.2",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbe789d04bf14543f03c4b60cd494148aa79438c8440ae7d81a7778147745c3"
+checksum = "444405bbb1a762387aa22dd569429533b54a1d8759d35d3b64cb39b0293eaa19"
 dependencies = [
  "cfg-if",
  "dashmap",
@@ -1031,7 +1031,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.1",
+ "rand 0.9.2",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1095,6 +1095,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -1258,7 +1264,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1399,6 +1405,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,9 +1486,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lettre"
-version = "0.11.16"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ffd14fa289730e3ad68edefdc31f603d56fe716ec38f2076bb7410e09147c2"
+checksum = "5cb54db6ff7a89efac87dba5baeac57bb9ccd726b49a9b6f21fb92b3966aaf56"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1489,7 +1506,7 @@ dependencies = [
  "nom",
  "percent-encoding",
  "quoted_printable",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tokio-native-tls",
  "url",
@@ -1548,9 +1565,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
 dependencies = [
  "hashbrown 0.15.3",
 ]
@@ -1952,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -2068,9 +2085,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.18"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2084,12 +2101,10 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls-pki-types",
@@ -2124,21 +2139,23 @@ dependencies = [
 
 [[package]]
 name = "runegate"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix-files",
  "actix-governor",
  "actix-session",
  "actix-web",
+ "anyhow",
  "awc",
  "dotenvy",
  "futures",
  "fxhash",
- "governor 0.10.0",
+ "governor 0.10.1",
+ "hex",
  "jsonwebtoken",
  "lettre",
  "lru",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -2291,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -2303,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -2403,6 +2420,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2577,20 +2604,22 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2650,44 +2679,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.1"
+name = "toml_datetime"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -2706,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags",
  "bytes",
@@ -2748,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-actix-web"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2340b7722695166c7fc9b3e3cd1166e7c74fedb9075b8f0c74d3822d2e41caf5"
+checksum = "5360edd490ec8dee9fedfc6a9fd83ac2f01b3e1996e3261b9ad18a61971fe064"
 dependencies = [
  "actix-web",
  "mutually_exclusive_features",
@@ -2916,9 +2943,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -3272,9 +3299,6 @@ name = "winnow"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runegate"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Hans Van Wesenbeeck <hvw@aivolution.ch>"]
 license = "Apache-2.0"
 edition = "2024"
@@ -19,25 +19,27 @@ awc = { version = "3.4.0", features = ["openssl"] }
 dotenvy = "0.15.7"
 futures = "0.3.30"
 jsonwebtoken = "9.3.1"
-lettre = { version = "0.11.16", features = ["smtp-transport", "tokio1", "builder", "tokio1-native-tls"] }
+lettre = { version = "0.11.18", features = ["smtp-transport", "tokio1", "builder", "tokio1-native-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
-toml = "0.8.22"
-uuid = { version = "1.16.0", features = ["v4"] }
+serde_json = "1.0.143"
+toml = "0.9.5"
+uuid = { version = "1.18.0", features = ["v4"] }
 # Tracing dependencies
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tracing-bunyan-formatter = "0.3.9"
 tracing-log = "0.2.0"
-tracing-actix-web = "0.7.9"
+tracing-actix-web = "0.7.19"
 
 # Rate limiting dependencies
-governor = "0.10.0"
+governor = "0.10.1"
 actix-governor = "0.8.0"
 fxhash = "0.2.1"  # Fast hashing for keys
-lru = "0.14.0"    # LRU cache for rate limiting storage
-rand = "0.9.1"
+lru = "0.16.0"    # LRU cache for rate limiting storage
+rand = "0.9.2"
+hex = "0.4.3"     # For decoding hex session keys
+anyhow = "1.0"    # Error handling for session store
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12.18", features = ["json"] }
+tokio = { version = "1.47.1", features = ["full"] }
+reqwest = { version = "0.12.23", features = ["json"] }

--- a/deploy/nginx/runegate.conf
+++ b/deploy/nginx/runegate.conf
@@ -14,6 +14,11 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         
+        # Essential for session cookie handling
+        proxy_set_header Cookie $http_cookie;
+        proxy_cookie_path / /;
+        proxy_cookie_domain localhost $host;
+        
         # Required for WebSocket support (if needed)
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -23,6 +28,9 @@ server {
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
+        
+        # Disable proxy buffering for real-time responses
+        proxy_buffering off;
     }
 
     # SSL configuration (uncomment when you have SSL certificates)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,7 @@ This directory contains utility scripts to help with development and testing of 
 - **start_test_server.sh** - Starts a Runegate server in test mode
 - **shutdown_server.sh** - Gracefully shuts down a running Runegate server
 - **run_integration_tests.sh** - Automates running integration tests against a test server
+- **test_token.sh** - Generates and/or verifies JWT tokens using the project's .env
 
 ## Development Scripts
 
@@ -37,3 +38,23 @@ The script will:
 4. Create a PR description with commit details and a checklist
 5. Show you a preview before submitting
 6. Create the PR using GitHub CLI
+
+### Generating a test JWT token
+
+The `test_token.sh` script runs the `examples/test_jwt_validation.rs` helper against your current `.env`:
+
+```bash
+# Generate a token for a specific email (default action: create)
+./scripts/test_token.sh user@example.com
+
+# Explicitly specify action (create|verify)
+./scripts/test_token.sh user@example.com create
+
+# Verify an existing token
+./scripts/test_token.sh user@example.com verify <TOKEN>
+```
+
+Notes:
+- The script automatically loads `.env` from the repository root if present.
+- Make sure `RUNEGATE_JWT_SECRET` is set in your `.env` to produce reproducible tokens.
+- The example will also print a ready-to-click `/auth?token=...` URL for local testing.

--- a/scripts/test_token.sh
+++ b/scripts/test_token.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Quick token generation script (relative to repo root)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Load .env if present (export all vars during sourcing)
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+EMAIL="${1:-test@example.com}"
+ACTION="${2:-create}"
+
+cargo run --example test_jwt_validation "${EMAIL}" "${ACTION}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 pub mod email;
 pub mod send_magic_link;
 pub mod auth;
-pub mod proxy;
 pub mod logging;
-pub mod middleware;
 pub mod rate_limit;
+pub mod memory_session_store;
+pub mod middleware;
+pub mod proxy;

--- a/src/memory_session_store.rs
+++ b/src/memory_session_store.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+use actix_session::storage::{LoadError, SaveError, SessionKey, SessionStore, UpdateError};
+use actix_web::cookie::time::Duration;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use uuid::Uuid;
+use tracing::{debug, error, info};
+
+#[derive(Debug, Clone)]
+pub struct MemorySessionStore {
+    sessions: Arc<RwLock<HashMap<String, HashMap<String, String>>>>,
+}
+
+impl MemorySessionStore {
+    pub fn new() -> Self {
+        Self {
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+impl Default for MemorySessionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionStore for MemorySessionStore {
+    async fn load(&self, session_key: &SessionKey) -> Result<Option<HashMap<String, String>>, LoadError> {
+        let key = session_key.as_ref();
+        info!("[MEMORY_STORE - LOAD] Loading session data for key: {}", key);
+        
+        match self.sessions.read() {
+            Ok(sessions) => {
+                info!("[MEMORY_STORE - LOAD] Available session keys: {:?}", sessions.keys().collect::<Vec<_>>());
+                let result = sessions.get(key).cloned();
+                info!("[MEMORY_STORE - LOAD] Session data loaded for key '{}': {:?} entries", key, result.as_ref().map(|s| s.len()));
+                if result.is_none() {
+                    info!("[MEMORY_STORE - LOAD] Session key '{}' not found in store", key);
+                }
+                Ok(result)
+            }
+            Err(e) => {
+                error!("Failed to acquire read lock: {}", e);
+                Err(LoadError::Other(anyhow::anyhow!("Failed to acquire read lock: {}", e)))
+            }
+        }
+    }
+
+    async fn save(
+        &self,
+        session_data: HashMap<String, String>,
+        _ttl: &Duration,
+    ) -> Result<SessionKey, SaveError> {
+        // Use the session framework's key generation instead of our own
+        let key_string = Uuid::new_v4().to_string();
+        let session_key = SessionKey::try_from(key_string.clone())
+            .map_err(|e| SaveError::Other(anyhow::anyhow!("Failed to create SessionKey: {}", e)))?;
+        
+        let key_for_storage = session_key.as_ref();
+        info!("[MEMORY_STORE - SAVE] Saving session data for key: {}, entries: {}", key_for_storage, session_data.len());
+        
+        match self.sessions.write() {
+            Ok(mut sessions) => {
+                sessions.insert(key_for_storage.to_string(), session_data);
+                info!("[MEMORY_STORE - SAVE] Session data saved successfully for key: {}", key_for_storage);
+                Ok(session_key)
+            }
+            Err(e) => {
+                error!("Failed to acquire write lock: {}", e);
+                Err(SaveError::Other(anyhow::anyhow!("Failed to acquire write lock: {}", e)))
+            }
+        }
+    }
+
+    async fn update(
+        &self,
+        session_key: SessionKey,
+        session_data: HashMap<String, String>,
+        _ttl: &Duration,
+    ) -> Result<SessionKey, UpdateError> {
+        let key = session_key.as_ref();
+        info!("[MEMORY_STORE - UPDATE] Updating session data for key: {}, entries: {}", key, session_data.len());
+        
+        match self.sessions.write() {
+            Ok(mut sessions) => {
+                sessions.insert(key.to_string(), session_data);
+                info!("[MEMORY_STORE - UPDATE] Session data updated successfully for key: {}", key);
+                Ok(session_key)
+            }
+            Err(e) => {
+                error!("Failed to acquire write lock: {}", e);
+                Err(UpdateError::Other(anyhow::anyhow!("Failed to acquire write lock: {}", e)))
+            }
+        }
+    }
+
+    async fn update_ttl(&self, _session_key: &SessionKey, _ttl: &Duration) -> Result<(), anyhow::Error> {
+        // In-memory store doesn't need to update TTL since sessions live for the process lifetime
+        Ok(())
+    }
+
+    async fn delete(&self, session_key: &SessionKey) -> Result<(), anyhow::Error> {
+        let key = session_key.as_ref();
+        debug!("Deleting session data for key: {}", key);
+        
+        match self.sessions.write() {
+            Ok(mut sessions) => {
+                let removed = sessions.remove(key);
+                debug!("Session deletion result for key {}: {:?}", key, removed.is_some());
+                Ok(())
+            }
+            Err(e) => {
+                error!("Failed to acquire write lock for deletion: {}", e);
+                Err(anyhow::anyhow!("Failed to acquire write lock: {}", e))
+            }
+        }
+    }
+}

--- a/src/send_magic_link.rs
+++ b/src/send_magic_link.rs
@@ -9,10 +9,12 @@ pub fn send_magic_link(
     config: &EmailConfig,
     recipient_email: &str,
     login_url: &str,
+    expiry_minutes: u64,
 ) -> Result<(), Box<dyn Error>> {
     let body = config
         .body_template
-        .replace("{login_url}", login_url);
+        .replace("{login_url}", login_url)
+        .replace("{expiry_minutes}", &expiry_minutes.to_string());
 
     let email = Message::builder()
         .from(config.from_address.parse::<Mailbox>()?)

--- a/static/login.html
+++ b/static/login.html
@@ -110,7 +110,7 @@
             if (path === '/login.html') {
                 return '';
             }
-            // If we're behind a proxy (e.g., /neufallenbach/login.html), extract the base path
+            // If we're behind a proxy (e.g., /proxyurl/login.html), extract the base path
             const match = path.match(/^(\/[^\/]+)\//); 
             return match ? match[1] : '';
         }


### PR DESCRIPTION
Summary:
- Fix session persistence and auth flow:
  - Shared in-memory session store across workers
  - Correct middleware order so auth sees the session
  - /proxy/* → target root mapping
  - Strip Runegate session cookie from upstream to avoid collisions
- Identity propagation (opt-in):
  - Inject X-Runegate-Authenticated, X-Runegate-User, X-Forwarded-User, X-Forwarded-Email
  - Strip any client-supplied versions to prevent spoofing
  - Controlled via RUNEGATE_IDENTITY_HEADERS (default: true)
- Configurability and safety:
  - RUNEGATE_COOKIE_DOMAIN (host-only default)
  - RUNEGATE_SESSION_COOKIE_NAME (default: runegate_id)
  - RUNEGATE_DEBUG_ENDPOINTS to toggle /debug/* endpoints (auto disabled in production)
- Documentation:
  - Production deployment guide (HTTPS + subdomain)
  - Migration from path-based to subdomain
  - Identity To Target chapter (headers implemented; JWT keypair sketched)
  - Updated directory structure (memory_session_store.rs, rate_limit.rs)
- Scripts/cleanup:
  - Move test_token.sh to scripts/, make it repo-relative
  - Document test_token.sh in scripts/README.md
  - Remove tracked artifacts: .env.production, headers.txt, test_server.log, .test_server_pid, cookies.txt
  - Tighten .gitignore

Breaking/behavioral notes:
- Path-based mounting (example.com/app) is not supported out-of-the-box; subdomain (app.example.com) is the recommended model.
- Identity headers are opt-in and safe by default (stripped/reinjected). Targets can read X-Forwarded-User/Email if needed.

Testing:
- Auth flow verified end-to-end; session preserved across redirect to /proxy/.
- /debug/session and /debug/cookies confirm cookie presence and session keys.
- /debug/protected passes through auth middleware and returns authenticated=true.
- Proxy path fix delivers target service at /proxy/.

Future work:
- JWT identity to target (RS256/Ed25519) with short-lived tokens, optional JWKS.
