### PR TITLE
chore(lockfile): update Cargo.lock for 0.2.0 packaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "runegate"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "actix-files",
  "actix-governor",


### PR DESCRIPTION
This PR commits the updated Cargo.lock so that cargo package/publish runs cleanly for the 0.2.0 release. No code changes.