### PR TITLE
chore(release): 0.2.1 — version bump and architecture docs update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "runegate"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix-files",
  "actix-governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runegate"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Hans Van Wesenbeeck <hvw@aivolution.ch>"]
 license = "Apache-2.0"
 edition = "2024"


### PR DESCRIPTION
- Bump crate version to 0.2.1 and sync Cargo.lock
- Update docs/architecture-overview.md for subdomain routing
- Revise Nginx example for subdomain deployment
- Add notes on cookie domain and base URL env vars