### PR TITLE
docs: document RUNEGATE_STREAM_RESPONSES and nginx settings for large transfers; add example systemd unit for Uvicorn/Gradio target app

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ Target service reachability: Ensure Runegate can reach your protected app (e.g.,
 
 ---
 
+## 📡 Streaming Responses (Large Transfers)
+
+Runegate can stream upstream responses to clients without buffering when `RUNEGATE_STREAM_RESPONSES` is enabled. This improves long‑lived endpoints (upload progress, heartbeats) and very large downloads.
+
+- Enable in environment: `RUNEGATE_STREAM_RESPONSES=true`
+- nginx recommendations for large transfers:
+  - `client_max_body_size 10G;`
+  - `proxy_request_buffering off;` (stream upload bodies to Runegate)
+  - `proxy_buffering off;` (avoid buffering responses at nginx)
+  - `proxy_read_timeout 600s; proxy_send_timeout 600s;`
+- Target app behind proxies (Uvicorn/Starlette/FastAPI/Gradio):
+  - Start with `--proxy-headers --forwarded-allow-ips='*'` so absolute URLs and scheme match the external origin.
+
+When disabled (default), Runegate buffers upstream responses before returning them. Enable streaming for better UX on progress/heartbeat endpoints and to support multi‑GB downloads with lower memory usage.
+
+
 ## ⚙️ Configuration
 
 ### Email Setup

--- a/deploy/systemd/target-app-uvicorn.service.example
+++ b/deploy/systemd/target-app-uvicorn.service.example
@@ -1,0 +1,33 @@
+[Unit]
+Description=Target App (Uvicorn/Gradio)
+After=network-online.target wg-quick@wg0.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=aiboxapp
+Group=aiboxapp
+WorkingDirectory=/opt/aibox-app
+Environment="PYTHONUNBUFFERED=1"
+# Optional: app-specific env vars
+EnvironmentFile=-/etc/aibox-app.env
+
+ExecStart=/opt/aibox-app/venv/bin/uvicorn app:app \
+  --host 0.0.0.0 --port 7860 \
+  --proxy-headers --forwarded-allow-ips='*'
+
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+PrivateTmp=true
+NoNewPrivileges=true
+ProtectSystem=full
+ReadWritePaths=/opt/aibox-app /var/log/aibox-app /tmp
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=aibox-app
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
## Changes in this PR

This PR implements the **Response Streaming** feature.

## Commit History

 - **feature(stream): add RUNEGATE_STREAM_RESPONSES to stream upstream responses to clients; stream for all responses when enabled (better progress/heartbeat/downloads)**
 - **docs: document RUNEGATE_STREAM_RESPONSES and nginx settings for large transfers; add example systemd unit for Uvicorn/Gradio target app**


## Checklist

- [x] Documentation updated
- [x] Tests added/updated
- [x] Code reviewed


