### PR TITLE
release: 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "runegate"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "actix-files",
  "actix-governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runegate"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Hans Van Wesenbeeck <hvw@aivolution.ch>"]
 license = "Apache-2.0"
 edition = "2024"


### PR DESCRIPTION
Release 0.3.0\n\nHighlights:\n- Response streaming (feature-flagged): RUNEGATE_STREAM_RESPONSES streams upstream responses to clients. Better long‑poll endpoints (upload progress, heartbeat) and multi‑GB downloads without buffering.\n- Stream request bodies to upstream for large uploads; fewer timeouts and lower memory use.\n- Increase proxy timeouts to 600s to match nginx sample.\n- Forward Host and X‑Forwarded‑Proto to upstream; Uvicorn/Starlette proxy guidance.\n- nginx sample rewritten for TLS-first, HTTP→HTTPS redirect, correct headers, and streaming-friendly settings (proxy_request_buffering off, proxy_buffering off, gzip off).\n- Performance guide: docs/performance-tests.md with WireGuard + client→VPS iperf3 procedures, firewall rules, tuning, and upload time estimates.\n\nNotes:\n- RUNEGATE_STREAM_RESPONSES is off by default; enable via env when serving long‑lived responses or large downloads.\n- Prefer a dedicated subdomain; leave RUNEGATE_COOKIE_DOMAIN unset for host-only cookies unless cross‑subdomain scope is needed.