### PR TITLE
logging: gate TracingLogger via env; reduce verbose per-request logs to debug

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -644,3 +644,16 @@ net.ipv4.udp_wmem_min = 262144
 Apply with: `sudo sysctl --system`.
 
 See also: `docs/performance-tests.md` for repeatable iperf3 procedures and a full proxy checklist.
+
+### Request access logs
+
+Runegate can log every request via `TracingLogger`, which is useful in development but noisy in production.
+
+- Env: `RUNEGATE_REQUEST_LOGS` (default: off in production, on in development)
+- Recommended prod filters:
+
+```env
+RUST_LOG=runegate=info,actix_web=warn,awc=warn,tracing_actix_web=off
+```
+
+This disables per-request access logs while keeping essential app logs. To reduce logs without disabling entirely, set `tracing_actix_web=warn`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,43 +146,43 @@ async fn auth(
     match verify_token(token) {
         Ok(email) => {
             // If token is valid, mark the session as authenticated
-            info!("[AUTH_FLOW] About to set session data for user: {}", email);
+            debug!("[AUTH_FLOW] About to set session data for user: {}", email);
             
             // Check initial session state
-            info!("[AUTH_FLOW] Initial session status: {:?}", session.status());
-            info!("[AUTH_FLOW] Initial session entries: {:?}", session.entries());
+            debug!("[AUTH_FLOW] Initial session status: {:?}", session.status());
+            debug!("[AUTH_FLOW] Initial session entries: {:?}", session.entries());
             
             if let Err(e) = session.insert("authenticated", true) {
                 error!("Failed to set authenticated session: {}", e);
                 return HttpResponse::InternalServerError().json("Session error");
             }
-            info!("[AUTH_FLOW] Session insert authenticated=true: OK");
+            debug!("[AUTH_FLOW] Session insert authenticated=true: OK");
             
             if let Err(e) = session.insert("email", email.clone()) {
                 error!("Failed to set email in session: {}", e);
                 return HttpResponse::InternalServerError().json("Session error");
             }
-            info!("[AUTH_FLOW] Session insert email={}: OK", email);
+            debug!("[AUTH_FLOW] Session insert email={}: OK", email);
             
             // Check session after inserts
-            info!("[AUTH_FLOW] After inserts session status: {:?}", session.status());
-            info!("[AUTH_FLOW] After inserts session entries: {:?}", session.entries());
+            debug!("[AUTH_FLOW] After inserts session status: {:?}", session.status());
+            debug!("[AUTH_FLOW] After inserts session entries: {:?}", session.entries());
             
             // Force session save to ensure data persistence
             session.renew();
-            info!("[AUTH_FLOW] Session renewed to ensure persistence");
-            info!("[AUTH_FLOW] After renew session status: {:?}", session.status());
+            debug!("[AUTH_FLOW] Session renewed to ensure persistence");
+            debug!("[AUTH_FLOW] After renew session status: {:?}", session.status());
             
             // Verify session data was stored
             match session.get::<bool>("authenticated") {
-                Ok(Some(val)) => info!("[AUTH_FLOW] Session verification: authenticated={}", val),
+                Ok(Some(val)) => debug!("[AUTH_FLOW] Session verification: authenticated={}", val),
                 Ok(None) => warn!("[AUTH_FLOW] Session verification: authenticated=None (not found)"),
                 Err(e) => warn!("[AUTH_FLOW] Session verification error: {}", e),
             }
             
             // Also verify email
             match session.get::<String>("email") {
-                Ok(Some(val)) => info!("[AUTH_FLOW] Session verification: email={}", val),
+                Ok(Some(val)) => debug!("[AUTH_FLOW] Session verification: email={}", val),
                 Ok(None) => warn!("[AUTH_FLOW] Session verification: email=None (not found)"),
                 Err(e) => warn!("[AUTH_FLOW] Session verification error for email: {}", e),
             }
@@ -190,7 +190,7 @@ async fn auth(
             info!("✅ User {} authenticated successfully", email);
             
             // Debug: Show cookies being set
-            info!("[AUTH_DEBUG] About to redirect to /proxy/ - session should be set");
+            debug!("[AUTH_DEBUG] About to redirect to /proxy/ - session should be set");
             
             // Redirect to the protected service after successful auth
             HttpResponse::Found()
@@ -209,22 +209,22 @@ async fn auth(
 #[instrument(name = "auth_check_and_proxy", skip(payload, session), fields(path = %req.path(), method = %req.method()))]
 async fn auth_check_and_proxy(req: HttpRequest, payload: web::Payload, session: Session) -> Result<HttpResponse, Error> {
     // Check if user is authenticated
-    info!("[PROXY_AUTH - EVENT] Checking session for proxy request to: {}", req.path());
+    debug!("[PROXY_AUTH - EVENT] Checking session for proxy request to: {}", req.path());
     
     match session.get::<bool>("authenticated") {
-        Ok(Some(val)) => info!("[PROXY_AUTH - EVENT] Session authenticated result: Ok(Some({}))", val),
-        Ok(None) => info!("[PROXY_AUTH - EVENT] Session authenticated result: Ok(None)"),
-        Err(e) => info!("[PROXY_AUTH - EVENT] Session authenticated error: {}", e),
+        Ok(Some(val)) => debug!("[PROXY_AUTH - EVENT] Session authenticated result: Ok(Some({}))", val),
+        Ok(None) => debug!("[PROXY_AUTH - EVENT] Session authenticated result: Ok(None)"),
+        Err(e) => debug!("[PROXY_AUTH - EVENT] Session authenticated error: {}", e),
     }
     
     match session.get::<String>("email") {
-        Ok(Some(val)) => info!("[PROXY_AUTH - EVENT] Session email result: Ok(Some({}))", val),
-        Ok(None) => info!("[PROXY_AUTH - EVENT] Session email result: Ok(None)"),
-        Err(e) => info!("[PROXY_AUTH - EVENT] Session email error: {}", e),
+        Ok(Some(val)) => debug!("[PROXY_AUTH - EVENT] Session email result: Ok(Some({}))", val),
+        Ok(None) => debug!("[PROXY_AUTH - EVENT] Session email result: Ok(None)"),
+        Err(e) => debug!("[PROXY_AUTH - EVENT] Session email error: {}", e),
     }
     
     let is_authenticated = session.get::<bool>("authenticated").unwrap_or(None).unwrap_or(false);
-    info!("[PROXY_AUTH - EVENT] Final authenticated value: {}", is_authenticated);
+    debug!("[PROXY_AUTH - EVENT] Final authenticated value: {}", is_authenticated);
     
     if is_authenticated {
         // User is authenticated, proxy the request and inject identity headers

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -4,7 +4,7 @@ use actix_web::body::EitherBody;
 use actix_session::SessionExt;
 use futures::future::{ok, LocalBoxFuture, Ready};
 use std::task::{Context, Poll};
-use tracing::{info, warn, debug, instrument};
+use tracing::{warn, debug, instrument};
 use std::rc::Rc;
 
 pub struct AuthMiddleware;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -71,32 +71,32 @@ where
         
         // Get session from request extensions
         let session = req.get_session();
-        info!("Checking session for path: {}", path);
+        debug!("Checking session for path: {}", path);
         
         // Debug session status
         match session.status() {
-            actix_session::SessionStatus::Changed => info!("Session status: Changed"),
-            actix_session::SessionStatus::Purged => info!("Session status: Purged"),
-            actix_session::SessionStatus::Renewed => info!("Session status: Renewed"),
-            actix_session::SessionStatus::Unchanged => info!("Session status: Unchanged"),
+            actix_session::SessionStatus::Changed => debug!("Session status: Changed"),
+            actix_session::SessionStatus::Purged => debug!("Session status: Purged"),
+            actix_session::SessionStatus::Renewed => debug!("Session status: Renewed"),
+            actix_session::SessionStatus::Unchanged => debug!("Session status: Unchanged"),
         }
         
         // Check all session entries
-        info!("Session entries: {:?}", session.entries());
+        debug!("Session entries: {:?}", session.entries());
         
         // Check if user is authenticated
         let authenticated_result = session.get::<bool>("authenticated");
-        info!("Session authenticated result: {:?}", authenticated_result);
+        debug!("Session authenticated result: {:?}", authenticated_result);
         
         // Also check if email exists in session
         let email_result = session.get::<String>("email");
-        info!("Session email result: {:?}", email_result);
+        debug!("Session email result: {:?}", email_result);
         
         let authenticated = authenticated_result
             .map(|result| result.unwrap_or(false))
             .unwrap_or(false);
             
-        info!("Final authenticated value: {}", authenticated);
+        debug!("Final authenticated value: {}", authenticated);
             
         if authenticated {
             debug!("User is authenticated, allowing access to: {}", path);
@@ -107,7 +107,7 @@ where
                 Ok(res.map_into_left_body())
             })
         } else {
-            info!("Unauthenticated access attempt to {}, redirecting to login", path);
+            debug!("Unauthenticated access attempt to {}, redirecting to login", path);
             // Return early with a redirect response
             let (request, _) = req.into_parts();
             let response = HttpResponse::Found()


### PR DESCRIPTION
This PR reduces per-request logging overhead and makes request access logs opt-in.\n\nChanges:\n- Gate TracingLogger with RUNEGATE_REQUEST_LOGS (default: off in production, on in development).\n- Downgrade verbose per-request logs to debug:\n  - AUTH_FLOW introspection in auth()\n  - PROXY_AUTH session checks in auth_check_and_proxy()\n  - Middleware session details\n- Remove unused import.\n\nRecommended prod filters:\n- RUST_LOG=runegate=info,actix_web=warn,awc=warn,tracing_actix_web=off\n- RUNEGATE_REQUEST_LOGS=false\n\nEffect:\n- Lower overhead/noise during uploads and long-poll progress endpoints, while keeping essential info/warn/error logs in production.